### PR TITLE
#36 - Adding the ability to retrieve cached wheel files from poetry cache

### DIFF
--- a/orphedomos-maven-plugin/src/main/java/org/technologybrewery/orphedomos/mojo/RetrieveCachedWheelsMojo.java
+++ b/orphedomos-maven-plugin/src/main/java/org/technologybrewery/orphedomos/mojo/RetrieveCachedWheelsMojo.java
@@ -1,0 +1,22 @@
+package org.technologybrewery.orphedomos.mojo;
+
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.technologybrewery.habushu.RetrieveWheelsMojo;
+
+/**
+ * Helper mojo that handles the retrieving of wheel artifacts from poetry
+ * cache by artifactId and into a given targetDirectory during the 
+ * {@link LifecyclePhase#VALIDATE} build phase. 
+ *
+ * @param wheelDependencies A List of Wheel Dependencies which will identify wheel 
+ *                          files by {@WheelDependency.artifactId} in poetry cache and place them into 
+ *                          a given {@WheelDependency.targetDirectory}. This logic specifically targets
+ *                          wheel artifacts cached by the {@param cacheWheels} parameter and REQUIRES 
+ *                          the requested wheel to have first been cached prior to setting this config
+ * @throws HabushuException
+ */
+@Mojo(name = "retrieve-wheels", defaultPhase = LifecyclePhase.VALIDATE)
+public class RetrieveCachedWheelsMojo extends RetrieveWheelsMojo {
+    
+}

--- a/orphedomos-maven-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/orphedomos-maven-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -18,6 +18,7 @@
                         <id>default</id>
                         <phases>
                             <validate>
+                                org.technologybrewery.orphedomos:orphedomos-maven-plugin:retrieve-wheels
                                 org.technologybrewery.orphedomos:orphedomos-maven-plugin:verify-docker-environment
                             </validate>
                             <package>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <developerConnection>scm:git:ssh://git@github.com/TechnologyBrewery/orphedomos.git</developerConnection>
         <url>scm:git:ssh://git@github.com/TechnologyBrewery/orphedomos</url>
       <tag>HEAD</tag>
-  </scm>
+    </scm>
 
     <issueManagement>
         <system>GitHub Issues</system>
@@ -62,4 +62,12 @@
         </profile>
 
     </profiles>
+
+     <dependencies>
+        <dependency>
+            <groupId>org.technologybrewery.habushu</groupId>
+            <artifactId>habushu-maven-plugin</artifactId>
+            <version>2.10.1-SNAPSHOT</version>
+        </dependency>
+    </dependencies>   
 </project>


### PR DESCRIPTION
Orphedomos orchestrates and executes docker builds as part of a maven process. It has a phase where it verifies the docker environment. The goal of this ticket to extend the habushu logic that retrieves cached wheel files into orphedomos for the purpose of establishing python environments within a given docker image. Extending the retrieveWheels logic will allow orphedomos to define wheel dependencies needed for a docker image.

By extending this mojo the following configuration is now available:

**wheelDependencies**
Optional set of wheel dependencies to retrieve from poetry cache. This allows previously cached external wheel dependencies to be copied into a given target directory if it exists in poetry cache. This logic depends on wheels to have first been cached by cacheWheels habushu-maven-plugin configuration and executes during the VALIDATE maven phase. Warnings will be logged if the specified wheel isn't found.

```
  <plugin>
      <groupId>org.technologybrewery.orphedomos</groupId>
      <artifactId>orphedomos-maven-plugin</artifactId>
      <version>0.9.0-SNAPSHOT</version>
      <executions>
          <execution>
              <id>retrieve-wheels</id>
              <phase>validate</phase>
              <goals>
                  <goal>retrieve-wheels</goal>
              </goals>
              <configuration>
                  <wheelDependencies>
                      <wheelDependency>
                          <artifactId>foundation-core-python</artifactId>
                          <targetDirectory>${wheelOutputDirectory}</targetDirectory>
                      </wheelDependency>
                  </wheelDependencies>
              </configuration>
          </execution>
      </executions>
  </plugin>

```